### PR TITLE
Add architecture unit tests and refactor ApiAddCommand interface

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,22 +8,10 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="coverlet.MTP" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageVersion
-      Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid"
-      Version="3.6.0"
-    />
-    <PackageVersion
-      Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore"
-      Version="2.1.0"
-    />
-    <PackageVersion
-      Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus"
-      Version="5.24.0"
-    />
-    <PackageVersion
-      Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs"
-      Version="6.8.0"
-    />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.45" />
@@ -67,6 +55,7 @@
     <PackageVersion Include="Serilog.Sinks.MSSqlServer" Version="5.8.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="TngTech.ArchUnitNET" Version="0.13.3" />
     <PackageVersion Include="TUnit" Version="1.34.5" />
     <PackageVersion Include="TUnit.Mocks" Version="1.34.5-beta" />
     <PackageVersion Include="TUnit.Mocks.Logging" Version="1.34.5-beta" />

--- a/FileIt.Module.Services/FileIt.Module.Services.App/ApiAdd/ApiAddCommand.cs
+++ b/FileIt.Module.Services/FileIt.Module.Services.App/ApiAdd/ApiAddCommand.cs
@@ -9,7 +9,14 @@ namespace FileIt.Module.Services.App.ApiAdd;
 
 public interface IApiAddCommand
 {
-    Task ApiAdd(ApiRequest request);
+    Task ApiAdd(
+        string messageId,
+        string? queueName,
+        string? subject,
+        string? replyTo,
+        string? correlationId,
+        object? body
+    );
 }
 
 public class ApiAddCommand : IApiAddCommand
@@ -32,11 +39,18 @@ public class ApiAddCommand : IApiAddCommand
         _logger = logger;
     }
 
-    public async Task ApiAdd(ApiRequest request)
+    public async Task ApiAdd(
+        string messageId,
+        string? queueName,
+        string? subject,
+        string? replyTo,
+        string? correlationId,
+        object? body
+    )
     {
         _logger.LogInformation(ServicesEvents.LogApiAddRequest, "Simulating API action");
         var apiLogItem = await _apiLogRepo.AddAsync(
-            request.CorrelationId ?? string.Empty,
+            correlationId ?? string.Empty,
             "Request body",
             "Response body",
             "Imaginary"
@@ -46,8 +60,8 @@ public class ApiAddCommand : IApiAddCommand
         var response = new ApiAddResponse()
         {
             NodeId = apiLogItem!.Id,
-            CorrelationId = request.CorrelationId,
-            TopicName = request.ReplyTo!,
+            CorrelationId = correlationId,
+            TopicName = replyTo!,
         };
 
         _logger.LogDebug(

--- a/FileIt.Module.Services/FileIt.Module.Services.Host/ApiFunc.cs
+++ b/FileIt.Module.Services/FileIt.Module.Services.Host/ApiFunc.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
 using Azure.Messaging.ServiceBus;
-using FileIt.Domain.Entities.Api;
 using FileIt.Module.Services.App;
 using FileIt.Module.Services.App.ApiAdd;
 using Microsoft.Azure.Functions.Worker;
@@ -37,27 +35,15 @@ public class ApiFunc
         )
         {
             _logger.LogInformation(ServicesEvents.AddEvent, "ApiAdd started");
-            ApiAddPayload? payload = null;
             string? bodystr = message.Body?.ToString();
-            if (!string.IsNullOrWhiteSpace(bodystr))
-            {
-                payload = JsonSerializer.Deserialize<ApiAddPayload>(bodystr);
-                _logger.LogDebug(
-                    ServicesEvents.GetPayload,
-                    "ApiAdd payload:\n{@ApiPayload}",
-                    payload
-                );
-            }
-            var request = new ApiRequest(message.MessageId)
-            {
-                Body = payload,
-                CorrelationId = message.CorrelationId,
-                QueueName = _config.ApiAddQueueName,
-                ReplyTo = _config.ApiAddTopicName,
-                Subject = message.Subject,
-            };
-            _logger.LogDebug(ServicesEvents.ExecApiAdd, "ApiAdd request:\n{@ApiRequest}", request);
-            await _command.ApiAdd(request);
+            await _command.ApiAdd(
+                message.MessageId,
+                _config.ApiAddQueueName,
+                message.Subject,
+                _config.ApiAddTopicName,
+                message.CorrelationId,
+                bodystr
+            );
         }
     }
 }

--- a/FileIt.Module.Services/FileIt.Module.Services.Test/ApiAdd/TestApiFunc.cs
+++ b/FileIt.Module.Services/FileIt.Module.Services.Test/ApiAdd/TestApiFunc.cs
@@ -6,7 +6,7 @@ using FileIt.Module.Services.App.ApiAdd;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace FileIt.Module.Services.App.Test.ApiAdd;
+namespace FileIt.Module.Services.Test.ApiAdd;
 
 public class TestApiFunc
 {
@@ -46,15 +46,9 @@ public class TestApiFunc
             .Returns(new ApiLog() { Id = 1 });
 
         var messageId = "test-message-id";
-        var mockMessage = new ApiRequest(messageId)
-        {
-            Body = messageBody.ToString(),
-            ReplyTo = replyTo,
-            Subject = subject,
-            CorrelationId = clientRequestId,
-        };
+        var body = messageBody.ToString();
 
-        await target.ApiAdd(mockMessage);
+        await target.ApiAdd(messageId, null, subject, replyTo, clientRequestId, body);
 
         _apiLogRepoMock.VerifyAll();
         _broadcasterMock.VerifyAll();

--- a/FileIt.Module.Services/FileIt.Module.Services.Test/ArchTest.cs
+++ b/FileIt.Module.Services/FileIt.Module.Services.Test/ArchTest.cs
@@ -1,0 +1,86 @@
+using System.Xml.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+// Use static import for a more readable fluent API
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace FileIt.Module.Services.Test;
+
+public class ArchitectureTests
+{
+    // Load your architecture once for all tests to improve performance
+    private static readonly Architecture Architecture = new ArchLoader()
+        .LoadAssemblies(
+            typeof(FileIt.Domain.Interfaces.IAuditable).Assembly,
+            typeof(FileIt.Infrastructure.IInfrastructureConfig).Assembly,
+            typeof(FileIt.Module.Services.App.ServicesConfig).Assembly,
+            typeof(FileIt.Module.Services.Host.Health).Assembly
+        )
+        .Build();
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_Infrastructure()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Infrastructure.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_Host()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Module.Services.Host.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_App()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Module.Services.App.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Host_Should_Not_Have_Dependency_On_Domain()
+    {
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Module.Services.Host.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task App_Should_Not_Have_Dependency_On_Infrastructure()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Module.Services.App.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Infrastructure.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+}

--- a/FileIt.Module.Services/FileIt.Module.Services.Test/FileIt.Module.Services.Test.csproj
+++ b/FileIt.Module.Services/FileIt.Module.Services.Test/FileIt.Module.Services.Test.csproj
@@ -10,12 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.MTP" />
+    <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Mocks" />
     <PackageReference Include="TUnit.Mocks.Logging" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../FileIt.Module.Services.Host/FileIt.Module.Services.Host.csproj" />
     <ProjectReference Include="..\FileIt.Module.Services.App\FileIt.Module.Services.App.csproj" />
     <ProjectReference Include="..\..\FileIt.Infrastructure\FileIt.Infrastructure\FileIt.Infrastructure.csproj" />
     <ProjectReference Include="..\..\FileIt.Domain\FileIt.Domain\FileIt.Domain.csproj" />

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.App/WaitOnApiUpload/BasicApiAddHandler.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.App/WaitOnApiUpload/BasicApiAddHandler.cs
@@ -11,7 +11,7 @@ namespace FileIt.Module.SimpleFlow.App.WaitOnApiUpload;
 
 public interface IBasicApiAddHandler
 {
-    Task RunAsync(ApiAddResponse message);
+    Task RunAsync(string? correlationId, string? messageBody);
 }
 
 public class BasicApiAddHandler : IBasicApiAddHandler
@@ -39,14 +39,23 @@ public class BasicApiAddHandler : IBasicApiAddHandler
     /// </summary>
     /// <param name="message">the ServiceBusReceivedMessage</param>
     /// <returns></returns>
-    public async Task RunAsync(ApiAddResponse message)
+    public async Task RunAsync(string? correlationId, string? messageBody)
     {
-        string clientRequestId = message.CorrelationId ?? string.Empty;
+        string clientRequestId = correlationId ?? string.Empty;
+        var message = JsonSerializer.Deserialize<ApiAddResponse>(messageBody ?? string.Empty);
+        if (message == null)
+        {
+            _logger.LogWarning(
+                SimpleEvents.SimpleSubscriberReceiveFailed,
+                "Failed to deserialize ApiAddResponse"
+            );
+            throw new ApplicationException("Failed to deserialize ApiAddResponse!");
+        }
 
         _logger.LogInformation(
             SimpleEvents.SimpleSubscriberGetRequestLog,
-            "Get RequestLog by CorrelationId {CorrelationId}",
-            message.CorrelationId
+            "Processing message {@Message}",
+            message
         );
         SimpleRequestLog? entry = await _requestLogRepo.GetByClientRequestIdAsync(clientRequestId);
         if (entry == null)
@@ -72,7 +81,7 @@ public class BasicApiAddHandler : IBasicApiAddHandler
         );
         await _blobTool.MoveAsync(entry.BlobName, _config.WorkingContainer, _config.FinalContainer);
 
-        entry.ApiId = message.NodeId;
+        entry.ApiId = message!.NodeId;
 
         _logger.LogInformation(
             SimpleEvents.SimpleSubscriberUpdateRequestLog,

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/Health.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/Health.cs
@@ -2,7 +2,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
-namespace FileIt.Module.SimpleFlow;
+namespace FileIt.Module.SimpleFlow.Host;
 
 public class Health
 {

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/HelloWorld.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/HelloWorld.cs
@@ -4,7 +4,7 @@ using FileIt.Module.SimpleFlow.App;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace FileIt.Module.SimpleFlow;
+namespace FileIt.Module.SimpleFlow.Host;
 
 public class HelloWorld
 {

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleSubscriber.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleSubscriber.cs
@@ -1,12 +1,11 @@
 using System.Text.Json;
 using Azure.Messaging.ServiceBus;
-using FileIt.Domain.Entities.Api;
 using FileIt.Module.SimpleFlow.App;
 using FileIt.Module.SimpleFlow.App.WaitOnApiUpload;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace FileIt.Module.SimpleFlow;
+namespace FileIt.Module.SimpleFlow.Host;
 
 public class SimpleSubscriber
 {
@@ -46,21 +45,10 @@ public class SimpleSubscriber
             )
         )
         {
-            //LogFunctionStart(nameof(SimpleSubscriber));
             _logger.LogDebug(SimpleEvents.SimpleSubscriberReceive, "Receiving {@message}", message);
 
-            var response = JsonSerializer.Deserialize<ApiAddResponse>(message.Body.ToString());
-            if (response == null)
-            {
-                _logger.LogWarning(
-                    SimpleEvents.SimpleSubscriberReceiveFailed,
-                    "Failed to deserialize ApiAddResponse"
-                );
-                throw new ApplicationException("Failed to deserialize ApiAddResponse!");
-            }
             _logger.LogInformation(SimpleEvents.SimpleSubscriber, "Processing ApiAddResponse");
-            await _responseHandler.RunAsync(response);
-            //LogFunctionEnd(nameof(SimpleSubscriber));
+            await _responseHandler.RunAsync(message.CorrelationId, message.Body?.ToString());
         }
     }
 }

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleTest.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleTest.cs
@@ -4,7 +4,7 @@ using FileIt.Module.SimpleFlow.App;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace FileIt.Module.SimpleFlow;
+namespace FileIt.Module.SimpleFlow.Host;
 
 public class SimpleTest
 {

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleWatcher.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Host/SimpleWatcher.cs
@@ -5,7 +5,7 @@ using FileIt.Module.SimpleFlow.App;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace FileIt.Module.SimpleFlow;
+namespace FileIt.Module.SimpleFlow.Host;
 
 public class SimpleWatcher
 {

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/ArchTest.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/ArchTest.cs
@@ -1,0 +1,86 @@
+using System.Xml.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+// Use static import for a more readable fluent API
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace FileIt.Module.SimpleFlow.Test;
+
+public class ArchitectureTests
+{
+    // Load your architecture once for all tests to improve performance
+    private static readonly Architecture Architecture = new ArchLoader()
+        .LoadAssemblies(
+            typeof(FileIt.Domain.Interfaces.IAuditable).Assembly,
+            typeof(FileIt.Infrastructure.IInfrastructureConfig).Assembly,
+            typeof(FileIt.Module.SimpleFlow.App.SimpleConfig).Assembly,
+            typeof(FileIt.Module.SimpleFlow.Host.Health).Assembly
+        )
+        .Build();
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_Infrastructure()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Infrastructure.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_Host()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Module.SimpleFlow.Host.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Domain_Should_Not_Have_Dependency_On_App()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Module.SimpleFlow.App.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task Host_Should_Not_Have_Dependency_On_Domain()
+    {
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Domain.");
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Module.SimpleFlow.Host.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+
+    [Test]
+    public async Task App_Should_Not_Have_Dependency_On_Infrastructure()
+    {
+        var testLayer = Types().That().HaveFullNameContaining("FileIt.Module.SimpleFlow.App.");
+        var targetLayer = Types().That().HaveFullNameContaining("FileIt.Infrastructure.");
+
+        // Define the architectural rule
+        var rule = Types().That().Are(testLayer).Should().NotDependOnAny(targetLayer);
+
+        bool isValid = rule.HasNoViolations(Architecture);
+        await Assert.That(isValid).IsTrue();
+    }
+}

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/BasicApiAddHandlerTest.cs
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/BasicApiAddHandlerTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FileIt.Domain.Entities;
 using FileIt.Domain.Entities.Api;
 using FileIt.Domain.Interfaces;
@@ -45,8 +46,6 @@ public class BasicApiAddHandlerTest
             ClientRequestId = correlationId,
             BlobName = blobName,
         };
-        var message = new ApiAddResponse { CorrelationId = correlationId, NodeId = nodeId };
-
         _requestLogRepoMock.GetByClientRequestIdAsync(correlationId).Returns(requestLog);
 
         _blobToolMock
@@ -65,7 +64,18 @@ public class BasicApiAddHandlerTest
             )
             .Returns(requestLog);
 
-        await _handler.RunAsync(message);
+        var respose = new ApiAddResponse
+        {
+            CorrelationId = correlationId,
+            NodeId = nodeId,
+            TopicName = "test-topic",
+            Subject = "test-subject",
+            StatusCode = "200",
+            Exception = null,
+        };
+        var messageBody = JsonSerializer.Serialize(respose);
+
+        await _handler.RunAsync(correlationId, messageBody);
 
         _requestLogRepoMock.VerifyAll();
         _blobToolMock.VerifyAll();
@@ -75,13 +85,11 @@ public class BasicApiAddHandlerTest
     public async Task RunAsync_WithNullRequestLog_ThrowsException()
     {
         var correlationId = "test-correlation-id";
-        var message = new ApiAddResponse { CorrelationId = correlationId };
-
         _requestLogRepoMock
             .GetByClientRequestIdAsync(correlationId)
             .Returns((SimpleRequestLog?)null);
 
-        await Assert.ThrowsAsync<Exception>(() => _handler.RunAsync(message));
+        await Assert.ThrowsAsync<Exception>(() => _handler.RunAsync(correlationId, string.Empty));
     }
 
     [Test]
@@ -89,11 +97,10 @@ public class BasicApiAddHandlerTest
     {
         var correlationId = "test-correlation-id";
         var requestLog = new SimpleRequestLog { ClientRequestId = correlationId, BlobName = null };
-        var message = new ApiAddResponse { CorrelationId = correlationId };
 
         _requestLogRepoMock.GetByClientRequestIdAsync(correlationId).Returns(requestLog);
 
-        await Assert.ThrowsAsync<Exception>(() => _handler.RunAsync(message));
+        await Assert.ThrowsAsync<Exception>(() => _handler.RunAsync(correlationId, string.Empty));
     }
 
     [Test]
@@ -106,8 +113,6 @@ public class BasicApiAddHandlerTest
             ClientRequestId = string.Empty,
             BlobName = blobName,
         };
-        var message = new ApiAddResponse { CorrelationId = null, NodeId = nodeId };
-
         _requestLogRepoMock.GetByClientRequestIdAsync(string.Empty).Returns(requestLog);
 
         _blobToolMock
@@ -121,7 +126,19 @@ public class BasicApiAddHandlerTest
             )
             .Returns(requestLog);
 
-        await _handler.RunAsync(message);
+        var messageBody = JsonSerializer.Serialize(
+            new ApiAddResponse
+            {
+                CorrelationId = string.Empty,
+                NodeId = nodeId,
+                TopicName = "test-topic",
+                Subject = "test-subject",
+                StatusCode = "200",
+                Exception = null,
+            }
+        );
+
+        await _handler.RunAsync(null, messageBody);
 
         _requestLogRepoMock.VerifyAll();
         _blobToolMock.VerifyAll();

--- a/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/FileIt.Module.SimpleFlow.Test.csproj
+++ b/FileIt.Module.SimpleFlow/FileIt.Module.SimpleFlow.Test/FileIt.Module.SimpleFlow.Test.csproj
@@ -10,12 +10,16 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.MTP" />
+    <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Mocks" />
     <PackageReference Include="TUnit.Mocks.Logging" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../FileIt.Domain/FileIt.Domain/FileIt.Domain.csproj" />
+    <ProjectReference Include="../../FileIt.Infrastructure/FileIt.Infrastructure/FileIt.Infrastructure.csproj" />
+    <ProjectReference Include="../FileIt.Module.SimpleFlow.Host/FileIt.Module.SimpleFlow.Host.csproj" />
     <ProjectReference Include="..\FileIt.Module.SimpleFlow.App\FileIt.Module.SimpleFlow.App.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Introduced architecture tests to ensure proper layer dependencies.
- Refactored ApiAddCommand to accept individual parameters instead of a single ApiRequest object.
- Updated BasicApiAddHandler and related tests to accommodate the new method signature.
- Added necessary package references for ArchUnitNET.